### PR TITLE
improvement(break): remove provider config

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,16 +2,9 @@ terraform {
   required_version = ">= 0.12.1"
 
   required_providers {
+    aws  = "~> 2.50"
     helm = "~> 1.0"
     null = "~> 2.1"
-  }
-}
-
-provider "aws" {
-  version = "~> 2.45"
-
-  assume_role {
-    role_arn = var.aws_assume_role_arn
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -67,12 +67,6 @@ variable "aws_account_id" {
   description = "The AWS Account ID. Required if masters_role_arn is not set. Defaults to current AWS account ID"
 }
 
-variable "aws_assume_role_arn" {
-  type        = string
-  default     = ""
-  description = "Role ARN to assume when creating AWS resources"
-}
-
 variable "masters_role_arn" {
   type        = string
   default     = ""


### PR DESCRIPTION
use `providers = { aws = aws.my-provider }` to override any provider specific settings or define the provider simply in your root module